### PR TITLE
Removing validation of data payload when validating a data response.

### DIFF
--- a/notary-api/src/facade/notarizeFacade/validateData.js
+++ b/notary-api/src/facade/notarizeFacade/validateData.js
@@ -18,7 +18,6 @@ const dataValidationResults =
  */
 export const validateData = async (orderAddress, sellerAddress, payload) => {
   const { msisdn } = payload;
-  if (!msisdn) return 'failure';
 
   const nonce = uuidv4();
 


### PR DESCRIPTION
The only payload validation was done at the notary api side. It was just this line of code doing that validation, now it's not returning failure if msisdn == undefined.

![](https://media.tenor.com/images/258addfe3528543124a9c703da4ccece/tenor.gif)