### PR TITLE
Remove unused variables from test setup

### DIFF
--- a/notary-signing-service/test/setup.js
+++ b/notary-signing-service/test/setup.js
@@ -1,7 +1,2 @@
 // TODO: This is a temporal solution, this file should not exist
 process.env.PRIVATE_KEY = '0x107be946709e41b7895eea9f2dacf998a0a9124acbb786f0fd1a826101581a07';
-process.env.ORDER_ADDRESS = '0xd56359a66d8ef7329507e5dd1f40aef7cd3320e7';
-process.env.RESPONSES_PERCENTAGE = 30;
-process.env.NOTARIZATION_FEE = 2;
-process.env.NOTARIZATION_TERMS_OF_SERVIE = 'The terms of service';
-process.env.SIGNATURE = '0x4c6ec1f7d74a998b33043bd9ae486f42f5b36f6b8e305d2b018106ab653f96c50d61b108a4428792c87f4bef8550c35d7c0d29169ceb4fca78fccf6b94e8e4b31b';


### PR DESCRIPTION
There is a typo suggested in #42, there is no need to fix it since it is not needed.
This PR removes all unused variables on the same file.
