### PR TITLE
NotarizationResult fixes

### DIFF
--- a/notary-api/package-lock.json
+++ b/notary-api/package-lock.json
@@ -2159,7 +2159,7 @@
       "dependencies": {
         "commander": {
           "version": "2.8.1",
-          "resolved": "http://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
           "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
           "requires": {
             "graceful-readlink": ">= 1.0.0"

--- a/notary-api/src/contractEventSubscribers/index.js
+++ b/notary-api/src/contractEventSubscribers/index.js
@@ -8,7 +8,7 @@ const notarizationRequestSubscriber = {
   ],
   callback: async (result) => {
     const { orderAddr, seller } = result.returnValues;
-    await notarize(orderAddr.toLowerCase(), seller.toLowerCase());
+    await notarize(orderAddr, seller);
   },
 };
 const subscribers = [notarizationRequestSubscriber];

--- a/notary-api/src/facade/notarizeFacade/notarizationResultRepository.js
+++ b/notary-api/src/facade/notarizeFacade/notarizationResultRepository.js
@@ -3,15 +3,18 @@ import { notarizationResults } from '../../utils/stores';
 export const fetchNotarizationResult = async (
   orderAddress,
   sellerAddress,
-  defaultResult = { error: 'Unknown data response.' },
+  defaultResult = { error: 'Unknown notarization' },
 ) => {
   try {
-    const payload = await notarizationResults.get(`${orderAddress}/${sellerAddress}`);
+    const key = `${orderAddress.toLowerCase()}/${sellerAddress.toLowerCase()}`;
+    const payload = await notarizationResults.get(key);
     return JSON.parse(payload);
   } catch (err) {
     return defaultResult;
   }
 };
 
-export const storeNotarizationResult = async (orderAddress, sellerAddress, payload) =>
-  notarizationResults.put(`${orderAddress}/${sellerAddress}`, JSON.stringify(payload));
+export const storeNotarizationResult = async (orderAddress, sellerAddress, payload) => {
+  const key = `${orderAddress.toLowerCase()}/${sellerAddress.toLowerCase()}`;
+  return notarizationResults.put(key, JSON.stringify(payload));
+}

--- a/notary-api/src/routes/buyers.js
+++ b/notary-api/src/routes/buyers.js
@@ -128,7 +128,7 @@ router.post(
       // eslint-disable-next-line no-restricted-syntax
       for (const { seller } of req.body.dataResponses) {
         // eslint-disable-next-line no-await-in-loop
-        const { result } = await fetchNotarizationResult(
+        const { error, result } = await fetchNotarizationResult(
           orderAddress,
           seller,
         );
@@ -137,11 +137,12 @@ router.post(
         const { signature } = await signingService.signNotarization({
           orderAddress,
           sellerAddress: seller,
-          wasAudited: result === 'success',
+          wasAudited: result === 'success' || result === 'failure',
           isDataValid: result === 'success',
         });
 
         dataResponses.push({
+          error,
           seller,
           result,
           signature,
@@ -174,7 +175,7 @@ router.post(
       // eslint-disable-next-line no-restricted-syntax
       for (const { seller } of req.body.dataResponses) {
         // eslint-disable-next-line no-await-in-loop
-        const { result } = await notarizeOnDemand(
+        const { error, result } = await notarizeOnDemand(
           orderAddress,
           seller,
         );
@@ -185,16 +186,17 @@ router.post(
           const { signature } = await signingService.signNotarization({
             orderAddress,
             sellerAddress: seller,
-            wasAudited: result === 'success',
+            wasAudited: result === 'success' || result === 'failure',
             isDataValid: result === 'success',
           });
           sig = signature;
         }
 
         dataResponses.push({
+          error,
           seller,
           result,
-          sig,
+          signature: sig,
         });
       }
 


### PR DESCRIPTION
### What does this Pull Request do?
1) The functions fetchNotarizationResult and storeNotarizationResult were being called using checksummed addresses and lowercased addresses for the same pair { order address, seller address } resulting in an unexpected response where the fetchNotarizationResult didn't find information for the specified arguments. This commit fixes the issue by lowercasing both parameters before fetching or storing.

2) There is a case where the Buyer API asks for results and the Notary API doesn't have yet the information to respond appropriately. The default response is "na" meaning that the Notary API didn't notarize the response, which is inaccurate, and instead with this commit it responds an error that the Buyer can handle.

### Does this Pull Request meet the acceptance criteria?
- [x] I have read the [Contribution guidelines](https://github.com/wibsonorg/notary-sdk/CONTRIBUTING.md).
- [x] I have read the [Code of Conduct](https://github.com/wibsonorg/notary-sdk/CODE_OF_CONDUCT.md).
