### PR TITLE
fix behavior when id saved is the same

### DIFF
--- a/notary-api/src/operations/saveSeller.js
+++ b/notary-api/src/operations/saveSeller.js
@@ -8,7 +8,9 @@ import { sellers } from '../utils/stores';
  */
 export const saveSeller = async (sellerAddress, sellerId) => {
   const seller = await sellers.safeFetch(sellerAddress);
-  if (seller) {
+  if (seller && seller === sellerId) {
+    return true;
+  } else if (seller) {
     return false;
   }
 

--- a/notary-api/test/operations/saveSeller.test.js
+++ b/notary-api/test/operations/saveSeller.test.js
@@ -9,7 +9,12 @@ it('saves seller id', async (assert) => {
   assert.true(sellers.put.called);
 });
 
-it('doesn`t save id when address already registered', async (assert) => {
+it('returns true when id is same as saved', async (assert) => {
+  await saveSeller('2', 3);
+  assert.false(sellers.put.called);
+});
+
+it('doesn`t save id when address already registered and id is not the same', async (assert) => {
   await saveSeller('2', 1);
   assert.false(sellers.put.called);
 });


### PR DESCRIPTION
### What does this Pull Request do?
Respond OK when the ad saved is the same as the one un the heads up.

### Are there points in the code the reviewer needs to double check?
no.

### Why was this Pull Request needed?
protocol v2.

### Does this Pull Request meet the acceptance criteria?
- [x] I have read the [Contribution guidelines](https://github.com/wibsonorg/notary-sdk/CONTRIBUTING.md).
- [x] I have read the [Code of Conduct](https://github.com/wibsonorg/notary-sdk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
